### PR TITLE
set $(P)$(R)EnergyBusy as a #controlPV so it is not autosaved.

### DIFF
--- a/energyApp/Db/energy_settings.req
+++ b/energyApp/Db/energy_settings.req
@@ -1,10 +1,10 @@
 # This file is used by autosave to determine what PVs to save
-# It is also used by txmOptics to determine what PVs to create
+# It is also used by energyApp to determine what PVs to create
 
 # This file contains all of the PVs used by the txmoptics base class.
 
 # Lines that begin with #controlPV are not saved by autosave,
-# but they are used by txmoptics.  
+# but they are used by energyApp.  
 # These PVs are not saved in the txmoptics configuration file.
 
 ##################################
@@ -27,7 +27,7 @@ $(P)$(R)EnergyInRange
 $(P)$(R)EnergyCalibrationUse
 $(P)$(R)EnergyMove
 $(P)$(R)EnergyTesting
-$(P)$(R)EnergyBusy
+#controlPV $(P)$(R)EnergyBusy
 
 #################
 # Shutter control

--- a/iocBoot/iocEnergy_2BM/autosave_old/README
+++ b/iocBoot/iocEnergy_2BM/autosave_old/README
@@ -1,3 +1,0 @@
-This directory contains the save/restore files to retain settings between IOC reboots.
-The distribution directory does not contain a auto_settings.sav file, but this will
-be created the first time the IOC is run.

--- a/src/energy/energy.py
+++ b/src/energy/energy.py
@@ -32,7 +32,7 @@ class Energy():
         self.epics_pvs = {**self.config_pvs, **self.control_pvs}
 
         # Wait 1 second for all PVs to connect
-        time.sleep(1)
+        time.sleep(2)
 
         for epics_pv in ('EnergyMove', 'EnergyMoveSet', 'EnergyArbitrary'):
             self.epics_pvs[epics_pv].add_callback(self.pv_callback)
@@ -46,14 +46,14 @@ class Energy():
         self.epics_pvs['EnergyStatus'].put('Done')
 
         log.setup_custom_logger("./energy.log")
-        print("./energy.log")
+        log.warning("./energy.log")
 
 
     def pv_callback(self, pvname=None, value=None, char_value=None, **kw):
         """Callback function that is called by pyEpics when certain EPICS PVs are changed
         """
 
-        print('pv_callback pvName=%s, value=%s, char_value=%s' % (pvname, value, char_value))
+        log.warning('pv_callback pvName=%s, value=%s, char_value=%s' % (pvname, value, char_value))
         if (pvname.find('EnergyMove') != -1) and (value == 1):
             thread = threading.Thread(target=self.energy_change, args=())
             thread.start()       
@@ -67,6 +67,8 @@ class Energy():
     def energy_change(self):
 
         if self.epics_pvs['EnergyStatus'].get(as_string=True) != 'Done' or self.epics_pvs['EnergyBusy'].get() == 1:
+            log.error('A0')
+
             return
             
         time.sleep(2) # for testing


### PR DESCRIPTION
 This caused the energy_move call back to stay busy in some situation